### PR TITLE
Add Shopee Singapore benchmark target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Modern web applications use advanced bot detection like Cloudflare, DataDome, an
 - **PerimeterX / HUMAN Security**
 - **Kasada**
 - **Reddit**
+- **Shopee SG**
 - <i>More systems coming soon</i>
 
 ### Browser Engine Support

--- a/config/benchmark_targets.py
+++ b/config/benchmark_targets.py
@@ -14,6 +14,7 @@ from utils.targets.check_bypass.akamai_protected import check_akamai_bypass
 from utils.targets.check_bypass.kasada_protected import check_kasada_bypass
 from utils.targets.check_bypass.perimeterx_protected import check_perimeterx_bypass
 from utils.targets.check_bypass.reddit import check_reddit_bypass
+from utils.targets.check_bypass.shopee import check_shopee_bypass
 from utils.targets.check_bypass.ticketmaster import check_ticketmaster_bypass
 
 
@@ -91,7 +92,13 @@ class BypassTargetsSettings(BaseModel):
                 name="reddit",
                 url="https://www.reddit.com/",
                 check_function="check_reddit_bypass",
-                description="Reddit bypass test"
+                description="Reddit bypass test",
+            ),
+            Target(
+                name="shopee_sg",
+                url="https://shopee.sg/",
+                check_function="check_shopee_bypass",
+                description="Shopee Singapore traffic verification redirect benchmark",
             ),
         ]
     )
@@ -108,6 +115,7 @@ class BypassTargetsSettings(BaseModel):
             "check_perimeterx_bypass": check_perimeterx_bypass,
             "check_kasada_bypass": check_kasada_bypass,
             "check_reddit_bypass": check_reddit_bypass,
+            "check_shopee_bypass": check_shopee_bypass,
         }
     )
 

--- a/config/benchmark_targets.py
+++ b/config/benchmark_targets.py
@@ -98,7 +98,7 @@ class BypassTargetsSettings(BaseModel):
                 name="shopee_sg",
                 url="https://shopee.sg/",
                 check_function="check_shopee_bypass",
-                description="Shopee Singapore traffic verification redirect benchmark",
+                description="Shopee Singapore traffic verification redirect bypass test",
             ),
         ]
     )

--- a/utils/targets/check_bypass/shopee.py
+++ b/utils/targets/check_bypass/shopee.py
@@ -1,0 +1,30 @@
+from engines.base import BrowserEngine
+
+
+BOT_REDIRECT_MARKER = "verify/traffic/error"
+
+
+async def check_shopee_bypass(engine: BrowserEngine) -> bool:
+    """
+    Check if the Shopee Singapore traffic verification bypass is successful.
+
+    Shopee bot detection redirects caught traffic to a URL containing
+    ``verify/traffic/error``. Unknown or unreadable current URL state fails
+    closed rather than counting as a bypass.
+
+    :param engine: BrowserEngine instance
+    """
+
+    try:
+        current_url = await engine.execute_js("return window.location.href;")
+    except Exception:
+        return False
+
+    if not isinstance(current_url, str):
+        return False
+
+    normalized_url = current_url.strip().lower()
+    if not normalized_url:
+        return False
+
+    return BOT_REDIRECT_MARKER not in normalized_url


### PR DESCRIPTION
### Summary
Adds **Shopee Singapore** (`shopee.sg`) as a new bypass benchmark target. Shopee uses a traffic-verification redirect for detected bots; this target verifies the engine lands on the real storefront instead of the verification page.

### Key Changes
- **New check function** `utils/targets/check_bypass/shopee.py`
  - `check_shopee_bypass()` reads `window.location.href` via the engine and fails closed (returns `False`) if the URL is missing, non-string, or contains the `verify/traffic/error` marker.
- **`config/benchmark_targets.py`**
  - Registers `shopee_sg` in `BypassTargetsSettings.targets`.
  - Wires `check_shopee_bypass` into the `checkers` dict.
  - Imports kept consistent with surrounding ordering.

### Detection Logic
Bot traffic is redirected to a URL containing `verify/traffic/error`. Absence of that marker after navigation indicates a successful bypass.

### Testing
- `python -m py_compile config/benchmark_targets.py` passes.
- Rebased on latest `main`; conflicts with the akamai/kasada/perimeterx/reddit targets resolved (both sets retained).